### PR TITLE
correct devdependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,8 +92,6 @@
     "lint-staged": "^8.0.4",
     "markdown-jsx-loader": "^3.0.2",
     "marked": "^0.5.1",
-    "moment": "^2.22.2",
-    "moment-timezone": "^0.5.27",
     "mt-changelog": "^0.6.1",
     "node-sass": "4.12.0",
     "postcss": "^7.0.16",
@@ -130,7 +128,9 @@
     "prop-types": "^15.6.2",
     "react-overlays": "^2.0.0-0",
     "uncontrollable": "^7.0.0",
-    "warning": "^4.0.2"
+    "warning": "^4.0.2",
+    "moment": "^2.22.2",
+    "moment-timezone": "^0.5.27"
   },
   "resolutions": {
     "babel-core": "7.0.0-bridge.0"


### PR DESCRIPTION
Changes introduced:
Moved moment and moment-timezones from devdependencies to dependencies. This is to resolve the `format not a method` error. 

How to test. 
Install the calendar module with this branch and It will install correctly and render events